### PR TITLE
Add font-detect-rhl,  size, and line-height to onscreen cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "deep-equal": "^2.0.5",
     "electron-is-dev": "^2.0.0",
     "electron-squirrel-startup": "^1.0.0",
+    "font-detect-rhl": "^1.0.5-1",
     "next": "^12.0.x",
     "postcss": "^8.4.14",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "postcss": "^8.4.14",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.8.0",
     "regenerator-runtime": "^0.13.9",
     "resource-workspace-rcl": "^2.1.1",
     "scripture-resources-rcl": "^5.2.1",

--- a/src/components/FontDropdown.jsx
+++ b/src/components/FontDropdown.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable test-selectors/button, test-selectors/onClick */
 import PropTypes from 'prop-types';
 import Box from "@mui/material/Box";
 import InputLabel from "@mui/material/InputLabel";

--- a/src/components/FontDropdown.jsx
+++ b/src/components/FontDropdown.jsx
@@ -1,0 +1,114 @@
+/* eslint-disable test-selectors/button, test-selectors/onClick */
+import PropTypes from 'prop-types';
+import Box from "@mui/material/Box";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import Select from "@mui/material/Select";
+import { Grid } from "@mui/material";
+import FontMenuItem from "./FontMenuItem";
+
+import {
+  useDetectFonts,
+  useAssumeGraphite,
+  fontList as fontsArray,
+  graphiteEnabledFontList as graphiteEnabledFontsArray
+} from 'font-detect-rhl';
+
+// import GraphiteEnabledWebFontsArray from '../embeddedWebFonts/GraphiteEnabledWebFonts.json';
+// import '../embeddedWebFonts/GraphiteEnabledWebFonts.css';
+
+export default function FontDropdown(fontDropdownProps) {
+  const { selectedFont, setSelectedFont } = fontDropdownProps;
+
+  // on click event for selecting font
+  const handleChange = (event) => {
+    setSelectedFont(event.target.value);
+  };
+
+  const styles = {
+    menuItem: {
+      width: "14rem",
+      display: "flex",
+      justifyContent: "space-between"
+    }
+  };
+
+  // Should Graphite-enabled fonts be detected?
+  const isGraphiteAssumed = useAssumeGraphite({});
+
+  // Detecting Graphite-enabled fonts
+  const detectedGEFonts = useDetectFonts({
+    fonts: isGraphiteAssumed ? graphiteEnabledFontsArray : []
+  });
+
+  const detectedGEFontsComponents =
+    isGraphiteAssumed &&
+    detectedGEFonts.map((font, index) => (
+      <MenuItem key={index} value={font.name} dense>
+        <FontMenuItem font={font} />
+      </MenuItem>
+    ));
+
+  const noneDetectedGEMsg = "none detected";
+  
+  //Detecting fonts:
+  const detectedFonts = useDetectFonts({ fonts: fontsArray });
+
+  /** Assemble dropdown menu item buttons for detected fonts */
+  const detectedFontsComponents = detectedFonts.map((font, index) => (
+    <MenuItem key={index} value={font.name} dense>
+      <FontMenuItem font={font} />
+    </MenuItem>
+  ));
+
+  //No fonts detected message for any group of fonts:
+  const noneDetectedMsg = "-none detected-";
+
+  /** Return the Dropdown */
+  return (
+    <Grid item xs={6} style={{ maxWidth: 300, padding: "0.25em" }}>
+      <Box sx={{ minWidth: 220 }}>
+        <FormControl fullWidth style={{ maxWidth: 250 }}>
+          <InputLabel id="demo-simple-select-label">Font</InputLabel>
+          <Select
+            labelId="demo-simple-select-label"
+            id="demo-simple-select"
+            value={selectedFont}
+            label="Font"
+            onChange={handleChange}
+          >
+            <MenuItem key={1} value="monospace">
+              default
+            </MenuItem>
+            {isGraphiteAssumed && <hr />}
+            <b>
+              {isGraphiteAssumed && "Graphite-Enabled Fonts:"}
+              {detectedGEFontsComponents.length === 0 &&
+                isGraphiteAssumed &&
+                noneDetectedGEMsg}
+            </b>
+            {detectedGEFontsComponents}
+            <hr />
+            <b>
+              Detected Fonts:{" "}
+              {detectedFontsComponents.length === 0 && noneDetectedMsg}
+            </b>
+            {detectedFontsComponents}
+          </Select>
+        </FormControl>
+      </Box>
+    </Grid>
+  );
+}
+
+FontDropdown.propTypes = {
+  /** Selected Font */
+  selectedFont: PropTypes.string,
+  /** Set Selected Font */
+  setSelectedFont: PropTypes.func.isRequired,
+};
+
+FontDropdown.defaultProps = {
+  selectedFont: 'monospace',
+};

--- a/src/components/FontDropdown.jsx
+++ b/src/components/FontDropdown.jsx
@@ -66,7 +66,7 @@ export default function FontDropdown(fontDropdownProps) {
 
   /** Return the Dropdown */
   return (
-    <Grid item xs={6} style={{ maxWidth: 300, padding: "0.25em" }}>
+    <Grid item style={{ maxWidth: 300, paddingTop: "0.25em", paddingBottom: "0.25em" }}>
       <Box sx={{ minWidth: 220 }}>
         <FormControl fullWidth style={{ maxWidth: 250 }}>
           <InputLabel id="demo-simple-select-label">Font</InputLabel>

--- a/src/components/FontMenuItem.jsx
+++ b/src/components/FontMenuItem.jsx
@@ -16,7 +16,7 @@ export default function FontMenuItem({ font }) {
 
   const styles = {
     menuItem: {
-      width: "14rem",
+      width: "13rem",
       display: "flex",
       justifyContent: "space-between"
     },

--- a/src/components/FontMenuItem.jsx
+++ b/src/components/FontMenuItem.jsx
@@ -1,0 +1,96 @@
+import React, { useState } from "react";
+import { PropTypes } from "prop-types";
+import { Popover, Typography } from "@mui/material";
+
+export default function FontMenuItem({ font }) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [previewFont, setPreviewFont] = useState({ name: "Arial" });
+
+  const handlePopoverOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handlePopoverClose = () => {
+    setAnchorEl(null);
+  };
+
+  const styles = {
+    menuItem: {
+      width: "14rem",
+      display: "flex",
+      justifyContent: "space-between"
+    },
+    previewltr: {
+      fontFamily: previewFont.name,
+      fontSize: "1em",
+      maxWidth: "35vw",
+      direction: "LTR"
+    },
+    previewrtl: {
+      fontFamily: previewFont.name,
+      fontSize: "1em",
+      maxWidth: "35vw",
+      direction: "RTL"
+    }
+  };
+
+  const open = Boolean(anchorEl);
+
+  return (
+    <div style={(styles.menuItem, { borderBottom: "1px outset" })}>
+      <div
+        style={styles.menuItem}
+        aria-owns={open ? "mouse-over-popover" : undefined}
+        aria-haspopup="true"
+        onMouseEnter={(e) => {
+          handlePopoverOpen(e);
+          setPreviewFont(font);
+        }}
+        onMouseLeave={handlePopoverClose}
+      >
+        <Typography variant="body2" component="div">
+          {font.name}&nbsp;
+        </Typography>
+        <Typography
+          style={{ width: "100%" }}
+          noWrap
+          variant="body2"
+          component="div"
+          style={{ fontFamily: font.name }}
+        >
+          {font.name}
+        </Typography>
+      </div>
+      <Popover
+        id="mouse-over-popover"
+        sx={{ pointerEvents: "none" }}
+        open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "right"
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left"
+        }}
+        onClose={handlePopoverClose}
+        disableRestoreFocus
+      >
+        <Typography sx={{ p: 1 }} style={styles.previewltr}>
+          He was with God<br />in the beginning.
+        </Typography>
+        <Typography sx={{ p: 1 }} style={styles.previewrtl}>
+          هَذَا كَانَ فِي ٱلْبَدْءِ عِنْدَ ٱللهِ.
+        </Typography>
+      </Popover>
+    </div>
+  );
+}
+
+FontMenuItem.propTypes = {
+  font: PropTypes.shape({
+    name: PropTypes.string,
+    id: PropTypes.string
+  })
+};

--- a/src/components/FontMenuItem.jsx
+++ b/src/components/FontMenuItem.jsx
@@ -52,7 +52,6 @@ export default function FontMenuItem({ font }) {
           {font.name}&nbsp;
         </Typography>
         <Typography
-          style={{ width: "100%" }}
           noWrap
           variant="body2"
           component="div"

--- a/src/components/FontSizeDropdown.jsx
+++ b/src/components/FontSizeDropdown.jsx
@@ -1,0 +1,62 @@
+/* eslint-disable test-selectors/button, test-selectors/onClick */
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import Box from "@mui/material/Box";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import Select from "@mui/material/Select";
+import { Grid } from "@mui/material";
+
+export default function FontSizeDropdown(fontSizeDropdownProps) {
+  const { selectedFontSize, setSelectedFontSize } = fontSizeDropdownProps;
+
+  const fontSizeArray = [
+    { size: '0.75em', verbose: '75%', id: '1' },
+    { size: '1.25em', verbose: '125%', id: '2' },
+    { size: '1.5em', verbose: '150%', id: '3' },
+    { size: '1em', verbose: 'default', id: '4' },
+  ];
+
+  // on click event for selecting font size
+  const handleChangeSize = (event) => {
+    setSelectedFontSize(event.target.value);
+  };
+
+  // Font Size Dropdown Items
+  const FontSizes =
+    fontSizeArray.map((fontSize, index) => (
+      <MenuItem key={index} value={fontSize.size}>{fontSize.verbose}</MenuItem>
+    ));
+
+  /** Return the Dropdown */
+  return (
+    <Grid item xs={3} style={{ padding: "0.25em" }}>
+      <Box sx={{ minWidth: 96 }}>
+        <FormControl fullWidth style={{ maxWidth: 96 }}>
+          <InputLabel id="demo-simple-select-label">FontSize</InputLabel>
+          <Select
+            labelId="demo-simple-select-label"
+            id="demo-simple-select"
+            value={selectedFontSize}
+            label="FontSize"
+            onChange={handleChangeSize}
+          >
+            {FontSizes}
+          </Select>
+        </FormControl>
+      </Box>
+    </Grid>
+  );
+}
+
+FontSizeDropdown.propTypes = {
+  /** Selected Font Size */
+  selectedFontSize: PropTypes.string,
+  /** Set Selected Font Size */
+  setSelectedFontSize: PropTypes.func.isRequired,
+};
+
+FontSizeDropdown.defaultProps = {
+  selectedFontSize: '1em',
+};

--- a/src/components/FontSizeDropdown.jsx
+++ b/src/components/FontSizeDropdown.jsx
@@ -30,7 +30,7 @@ export default function FontSizeDropdown(fontSizeDropdownProps) {
 
   /** Return the Dropdown */
   return (
-    <Grid item xs={3} style={{ padding: "0.25em" }}>
+    <Grid item style={{ padding: "0.25em" }}>
       <Box sx={{ minWidth: 96 }}>
         <FormControl fullWidth style={{ maxWidth: 96 }}>
           <InputLabel id="demo-simple-select-label">FontSize</InputLabel>

--- a/src/components/FontSizeDropdown.jsx
+++ b/src/components/FontSizeDropdown.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable test-selectors/button, test-selectors/onClick */
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Box from "@mui/material/Box";

--- a/src/components/LineHeightDropdown.jsx
+++ b/src/components/LineHeightDropdown.jsx
@@ -1,0 +1,62 @@
+/* eslint-disable test-selectors/button, test-selectors/onClick */
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import Box from "@mui/material/Box";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import Select from "@mui/material/Select";
+import { Grid } from "@mui/material";
+
+export default function LineHeightDropdown(lineHeightDropdownProps) {
+  const { selectedLineHeight, setSelectedLineHeight } = lineHeightDropdownProps;
+
+  const lineHeightArray = [
+    { size: '150%', verbose: '150%', id: '1' },
+    { size: '200%', verbose: '200%', id: '2' },
+    { size: '250%', verbose: '250%', id: '3' },
+    { size: 'normal', verbose: 'default', id: '4' },
+  ];
+
+  // on click event for selecting line height
+  const handleChangeLineHeight = (event) => {
+    setSelectedLineHeight(event.target.value);
+  };
+
+  // Line Height Dropdown Items
+ const LineHeights =
+  lineHeightArray.map((lineHeight, index) => (
+    <MenuItem key={index} value={lineHeight.size}>{lineHeight.verbose}</MenuItem>
+  ));
+
+  /** Return the Dropdown */
+  return (
+      <Grid item xs={2} style={{ padding: "0.25em" }}>
+        <Box sx={{ minWidth: 96 }}>
+          <FormControl fullWidth style={{ maxWidth: 96 }}>
+            <InputLabel id="demo-simple-select-label">LineHeight</InputLabel>
+            <Select
+              labelId="demo-simple-select-label"
+              id="demo-simple-select"
+              value={selectedLineHeight}
+              label="LineHeight"
+              onChange={handleChangeLineHeight}
+            >
+              {LineHeights}
+            </Select>
+          </FormControl>
+        </Box> 
+      </Grid>
+  );
+}
+
+LineHeightDropdown.propTypes = {
+  /** Selected Line Height */
+  selectedLineHeight: PropTypes.string,
+  /** Set Selected Line Height */
+  setSelectedLineHeight: PropTypes.func.isRequired,
+};
+
+LineHeightDropdown.defaultProps = {
+  selectedLineHeight: 'normal',
+};

--- a/src/components/LineHeightDropdown.jsx
+++ b/src/components/LineHeightDropdown.jsx
@@ -30,7 +30,7 @@ export default function LineHeightDropdown(lineHeightDropdownProps) {
 
   /** Return the Dropdown */
   return (
-      <Grid item xs={2} style={{ padding: "0.25em" }}>
+      <Grid item style={{ paddingTop: "0.25em", paddingBottom: "0.25em", paddingRight: "0.25em" }}>
         <Box sx={{ minWidth: 96 }}>
           <FormControl fullWidth style={{ maxWidth: 96 }}>
             <InputLabel id="demo-simple-select-label">LineHeight</InputLabel>

--- a/src/components/LineHeightDropdown.jsx
+++ b/src/components/LineHeightDropdown.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable test-selectors/button, test-selectors/onClick */
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Box from "@mui/material/Box";

--- a/src/components/ScriptureWorkspaceCard.js
+++ b/src/components/ScriptureWorkspaceCard.js
@@ -136,7 +136,7 @@ export default function ScriptureWorkspaceCard({
   //Example returning array
   const onRenderToolbar = ({items}) => [
     ...items,
-    <Grid container spacing={0} sx={{p: 1.5}} key='fontsettings'>
+    <Grid container spacing={0} sx={{p: 0}} key='fontsettings'>
       {fontButton}
       {fontSizeButton}
       {lineHeightButton}

--- a/src/components/ScriptureWorkspaceCard.js
+++ b/src/components/ScriptureWorkspaceCard.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext, useMemo, createElement } from 'react'
+import { useEffect, useState, useContext, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { Card, useCardState } from 'translation-helps-rcl'
 import { UsfmEditor } from 'uw-editor'
@@ -15,15 +15,6 @@ import { Grid } from "@mui/material"
 
 const CustomToolbarCloseButton = ({onClick}) => {
   return <Button style={{maxWidth: '30px', maxHeight: '54px', minWidth: '30px', minHeight: '54px'}} sx={{fontSize: 30}} variant="contained" onClick={onClick}>×</Button>
-}
-
-const CustomSettingComponent = () => {
-  return (
-    <label>
-      <p>Custom setting</p>
-      <input type="range" min="1" step="1" max="100" defaultValue="50"/>
-    </label>
-  );
 }
 
 export default function ScriptureWorkspaceCard({
@@ -109,13 +100,6 @@ export default function ScriptureWorkspaceCard({
     bookId,
   ])
 
-  // const editorProps = {
-  //   onSave: (bookCode,usfmText) => setDoSave(usfmText),
-  //   docSetId,
-  //   // usfmText: data.usfmText,
-  //   bookId: data.bookId,
-  // }
-
   let title = ''
   if (BIBLE_AND_OBS[bookId.toLowerCase()]) {
     title += BIBLE_AND_OBS[bookId.toLowerCase()]
@@ -149,12 +133,6 @@ export default function ScriptureWorkspaceCard({
     items: []
   })
 
-  //Example returning jsx
-  const onRenderSettings = ({items}) => {
-    const divider = items.find(item => item.key === "divider");
-    return <><CustomSettingComponent/>{divider}{items}</>
-  }
-
   //Example returning array
   const onRenderToolbar = ({items}) => [
     ...items,
@@ -163,7 +141,8 @@ export default function ScriptureWorkspaceCard({
       {fontSizeButton}
       {lineHeightButton}
     </Grid>,
-    <CustomToolbarCloseButton key="close"
+    <CustomToolbarCloseButton
+            key='close'
             id='card_close'
             onClick={removeBook} //Needs something else. Cannot be re-opened. Where is removeBook() defined?
           />
@@ -172,7 +151,6 @@ export default function ScriptureWorkspaceCard({
   return (
     <Card
       onRenderToolbar={onRenderToolbar}
-      onRenderSettings={onRenderSettings}
       filters={filters}
       itemIndex={itemIndex}
       setFilters={setFilters}

--- a/src/components/ScriptureWorkspaceCard.js
+++ b/src/components/ScriptureWorkspaceCard.js
@@ -136,7 +136,7 @@ export default function ScriptureWorkspaceCard({
   //Example returning array
   const onRenderToolbar = ({items}) => [
     ...items,
-    <Grid container spacing={0} sx={{p: 1.5}}>
+    <Grid container spacing={0} sx={{p: 1.5}} key='fontsettings'>
       {fontButton}
       {fontSizeButton}
       {lineHeightButton}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -46,9 +46,11 @@
 /*
   use Ezra for Hebrew characters and then Noto Sans for other characters
 */
+/*
 * {
   font-family: Ezra, Noto Sans;
 }
+*/
 
 @tailwind components;
 @tailwind utilities;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6641,6 +6641,7 @@ __metadata:
     prop-types: ^15.8.1
     react: ^18.2.0
     react-dom: ^18.2.0
+    react-icons: ^4.8.0
     regenerator-runtime: ^0.13.9
     resource-workspace-rcl: ^2.1.1
     scripture-resources-rcl: ^5.2.1
@@ -11973,6 +11974,15 @@ __metadata:
   peerDependencies:
     react: ^16.3.0 || ^17 || ^18
   checksum: 2c4b443543903e27b21f159c13ebc05cd2a0c70568d06ac7f9ea02b5267a0d1592c6073674e0bdbc38ade2aae3a0650f0dfecf739382efbeb13719a1e3a6ddcb
+  languageName: node
+  linkType: hard
+
+"react-icons@npm:^4.8.0":
+  version: 4.8.0
+  resolution: "react-icons@npm:4.8.0"
+  peerDependencies:
+    react: "*"
+  checksum: 4dbba7ad989c295b410e19b2a702722dae44368cb04b6515f9471353552f31ac80bd350f121d5bff79f81504b84039ede44d09e9f035f48bb1032e6eace126c4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6311,6 +6311,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"font-detect-rhl@npm:^1.0.5-1":
+  version: 1.0.5
+  resolution: "font-detect-rhl@npm:1.0.5"
+  dependencies:
+    prop-types: ^15.6.1
+    use-deep-compare: ^1.1.0
+  peerDependencies:
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  checksum: f8e82fa179a925ea94d2bcb315cd4ef40c0fa6cfb7874946a9e90235e6dbd8cfe2c76f52af71800ff5bc1bbc2a8493f6333abfbf0e2d6ecf50356ffb4b791583
+  languageName: node
+  linkType: hard
+
 "for-each@npm:^0.3.3":
   version: 0.3.3
   resolution: "for-each@npm:0.3.3"
@@ -6619,6 +6632,7 @@ __metadata:
     electron-squirrel-startup: ^1.0.0
     eslint: ^8.17.0
     eslint-config-next: 12.1.6
+    font-detect-rhl: ^1.0.5-1
     husky: ^8.0.1
     next: ^12.0.x
     npm: ^9.6.3


### PR DESCRIPTION
# Describe what your pull request addresses

* Incorporates font-detect-rhl
* Allows font to be set separately on each card as long as it is onscreen.
* Only shows graphite-enable fonts if Firefox is in use. (Needs to be expanded to include electronite-forge once available!)
* Includes setting font height and line height.
* Adds a custom close button ("×").

## Known issues
- Custom close button does not always successfully close.
- Custom close button sometimes does not allow re-opening of the same file that was closed.
- Reopening a different version of a closed book also re-opens the closed book.
- Custom close button closes all cards onscreen rather than just one card.

## For consideration
+ Add font settings at the Project level would be valuable. Could be set at "Create Project". Would need an Edit Project to change. And would need option to set with Upload Zip, and edit after uploaded...