### PR TITLE
tighten up, clean-up, shorten provided font list

### DIFF
--- a/src/components/FontDropdown.jsx
+++ b/src/components/FontDropdown.jsx
@@ -9,7 +9,6 @@ import FontMenuItem from "./FontMenuItem";
 
 import {
   useDetectFonts,
-  useAssumeGraphite,
   fontList as fontsArray,
   graphiteEnabledFontList as graphiteEnabledFontsArray
 } from 'font-detect-rhl';
@@ -26,11 +25,6 @@ export default function FontDropdown(fontDropdownProps) {
   };
 
   const styles = {
-    menuItem: {
-      width: "13rem",
-      display: "flex",
-      justifyContent: "space-between"
-    },
     fontHeading: {
       marginLeft: 5,
     },
@@ -38,60 +32,18 @@ export default function FontDropdown(fontDropdownProps) {
       marginLeft: 10,
       fontSize: "0.75em",
       fontStyle: 'italic',
-    },
-    providedFonts: {
-      fontSize: "0.87em",
     }
   };
 
-  /** Assemble dropdown menu item buttons for Web fonts over https*/
-  const embeddedWebFonts = [
-    { name: 'roboto', id: 'roboto' },
-  ];
-  const embeddedWebFontsComponents = embeddedWebFonts.map((font, index) => (
-    <MenuItem key={index} value={font.name} dense>
-      <FontMenuItem font={font} />
-    </MenuItem>
-  ));
-
-  /** Assemble dropdown menu item buttons for embedded Graphite-Enabled TTF fonts */
-  const embeddedGEFonts = [
-    { name: 'Ezra-shipped', id: 'ezra-shipped' },
-  ];
-  const embeddedGEFontsComponents = embeddedGEFonts.map((font, index) => (
-    <MenuItem key={index} value={font.name} dense>
-      <FontMenuItem font={font} />
-    </MenuItem>
-  ));
-
-  /** Assemble dropdown menu item buttons for embedded Google TTF fonts */
-  const embeddedGoogleFonts = [
-    { name: 'Noto-Sans-shipped', id: 'noto-sans-shipped' },
-  ];
-  const embeddedGoogleFontsComponents = embeddedGoogleFonts.map((font, index) => (
-    <MenuItem key={index} value={font.name} dense>
-      <FontMenuItem font={font} />
-    </MenuItem>
-  ));
-
-  // Should Graphite-enabled fonts be detected?
-  const isGraphiteAssumed = useAssumeGraphite({alwaysUse: true});
-
   // Detecting Graphite-enabled fonts
-  const detectedGEFonts = useDetectFonts({
-    fonts: isGraphiteAssumed ? graphiteEnabledFontsArray : []
-  });
+  const detectedGEFonts = useDetectFonts({ fonts: graphiteEnabledFontsArray });
 
-  const detectedGEFontsComponents =
-    isGraphiteAssumed &&
-    detectedGEFonts.map((font, index) => (
+  const detectedGEFontsComponents = detectedGEFonts.map((font, index) => (
       <MenuItem key={index} value={font.name} dense>
         <FontMenuItem font={font} />
       </MenuItem>
     ));
 
-  const noneDetectedGEMsg = "none detected";
-  
   //Detecting fonts:
   const detectedFonts = useDetectFonts({ fonts: fontsArray });
 
@@ -102,14 +54,11 @@ export default function FontDropdown(fontDropdownProps) {
     </MenuItem>
   ));
 
-  //No fonts detected message for any group of fonts:
-  const noneDetectedMsg = "-none detected-";
-
   /** Return the Dropdown */
   return (
-    <Grid item style={{ maxWidth: 300, paddingTop: "0.25em", paddingBottom: "0.25em" }}>
-      <Box sx={{ minWidth: 220 }}>
-        <FormControl fullWidth style={{ maxWidth: 250 }}>
+    <Grid item style={{ paddingTop: "0.25em", paddingBottom: "0.25em" }}>
+      <Box sx={{ minWidth: 250 }} >
+        <FormControl fullWidth style={{ maxWidth: 250 }} >
           <InputLabel id="demo-simple-select-label">Font</InputLabel>
           <Select
             labelId="demo-simple-select-label"
@@ -117,46 +66,43 @@ export default function FontDropdown(fontDropdownProps) {
             value={selectedFont}
             label="Font"
             onChange={handleChange}
+            style={{fontSize: "0.87em", minHeight: 30, maxHeight: 30 }}
           >
             <Typography style={styles.fontHeading}>
               <b>
                   Provided Fonts:{" "}
               </b>
             </Typography> 
-            <MenuItem key={1} value="Ezra-shipped, Noto-Sans-shipped" dense>
-              Ezra (עִבְרִית) & Noto Sans 
+            <MenuItem key={1} value="Ezra-shipped, Noto-Sans-shipped" dense >
+              <u>Ezra (עִבְרִית) & Noto Sans</u> 
             </MenuItem>
-            <MenuItem key={1} value="Noto-Sans-shipped" dense>
-              Noto Sans
-            </MenuItem>
-            <MenuItem key={1} value="Ezra-shipped" dense>
-              Ezra
-            </MenuItem>
+             {/* 
+              <MenuItem key={1} value="Noto-Sans-shipped" dense>
+                <u>Noto Sans</u>
+              </MenuItem>
+              <MenuItem key={1} value="Ezra-shipped" dense>
+                <u>Ezra</u>
+              </MenuItem>
+            */}
             <MenuItem key={1} value="roboto" dense >
-              Roboto
+              <u>Roboto</u>
             </MenuItem>
-            {isGraphiteAssumed && <Divider />}
+            {detectedGEFontsComponents.length != 0 && <Divider />}
             <Typography style={styles.fontHeading}>
               <b>
-                  {isGraphiteAssumed && "Local Graphite-Enabled Fonts: "}
+                  {detectedGEFontsComponents.length != 0 && "Local Graphite-Enabled Fonts:"}
               </b>
             </Typography>
             <Typography style={styles.subHeading}>
-              {isGraphiteAssumed && "(use Firefox)"}
+              {detectedGEFontsComponents.length != 0 && "(use Firefox)"}
             </Typography>
-              <b>
-                {detectedGEFontsComponents.length === 0 &&
-                  isGraphiteAssumed &&
-                  noneDetectedGEMsg}
-              </b>
             {detectedGEFontsComponents}
-            <Divider />
+            {detectedFontsComponents.length != 0 && <Divider />}
             <Typography style={styles.fontHeading}>
               <b>
-                Local Detected Fonts:{" "}
+              {detectedFontsComponents.length != 0 && "Local Detected Fonts:"}
               </b>
             </Typography>
-            {detectedFontsComponents.length === 0 && noneDetectedMsg}
             {detectedFontsComponents}
           </Select>
         </FormControl>

--- a/src/components/FontSizeDropdown.jsx
+++ b/src/components/FontSizeDropdown.jsx
@@ -32,16 +32,16 @@ export default function FontSizeDropdown(fontSizeDropdownProps) {
   /** Return the Dropdown */
   return (
     <Grid item style={{ padding: "0.25em" }} >
-      <Box sx={{ minWidth: 86 }} >
-        <FormControl fullWidth style={{ maxWidth: 86 }} >
+      <Box sx={{ minWidth: 81 }} >
+        <FormControl fullWidth style={{ maxWidth: 81 }} >
           <InputLabel id="demo-simple-select-label">FontSize</InputLabel>
           <Select
             labelId="demo-simple-select-label"
             id="demo-simple-select"
             value={selectedFontSize}
-            label="FontSize"
+            label="Font Size"
             onChange={handleChangeSize}
-            style={{fontSize: "0.95em", minHeight: 56, maxHeight: 56 }}
+            style={{fontSize: "0.87em", minHeight: 30, maxHeight: 30 }}
           >
             {FontSizes}
           </Select>

--- a/src/components/LineHeightDropdown.jsx
+++ b/src/components/LineHeightDropdown.jsx
@@ -31,16 +31,16 @@ export default function LineHeightDropdown(lineHeightDropdownProps) {
   /** Return the Dropdown */
   return (
       <Grid item style={{ paddingTop: "0.25em", paddingBottom: "0.25em", paddingRight: "0.25em" }}>
-        <Box sx={{ minWidth: 97 }}>
-          <FormControl fullWidth style={{ maxWidth: 97 }}>
+        <Box sx={{ minWidth: 91 }}>
+          <FormControl fullWidth style={{ maxWidth: 91 }}>
             <InputLabel id="demo-simple-select-label">LineHeight</InputLabel>
             <Select
               labelId="demo-simple-select-label"
               id="demo-simple-select"
               value={selectedLineHeight}
-              label="LineHeight"
+              label="Line Height"
               onChange={handleChangeLineHeight}
-              style={{fontSize: "0.95em", minHeight: 56, maxHeight: 56 }}
+              style={{fontSize: "0.87em", minHeight: 30, maxHeight: 30 }}
             >
               {LineHeights}
             </Select>

--- a/src/components/ScriptureWorkspaceCard.js
+++ b/src/components/ScriptureWorkspaceCard.js
@@ -14,7 +14,7 @@ import Button from '@mui/material/Button'
 import { Grid } from "@mui/material"
 
 const CustomToolbarCloseButton = ({onClick}) => {
-  return <Button style={{maxWidth: '30px', maxHeight: '54px', minWidth: '30px', minHeight: '54px'}} sx={{fontSize: 30}} variant="contained" onClick={onClick}>×</Button>
+  return <Button style={{maxWidth: '30px', maxHeight: '30px', minWidth: '30px', minHeight: '30px'}} sx={{fontSize: 30}} variant="contained" onClick={onClick}>×</Button>
 }
 
 export default function ScriptureWorkspaceCard({

--- a/src/components/ScriptureWorkspaceCard.js
+++ b/src/components/ScriptureWorkspaceCard.js
@@ -136,7 +136,7 @@ export default function ScriptureWorkspaceCard({
   //Example returning array
   const onRenderToolbar = ({items}) => [
     ...items,
-    <Grid container spacing={0} sx={{p: 0}} key='fontsettings'>
+    <Grid container spacing={0} sx={{p: 0, minWidth: 434}} key='fontsettings'>
       {fontButton}
       {fontSizeButton}
       {lineHeightButton}


### PR DESCRIPTION
# Describe what your pull request addresses

* Tightens up button presentation, taking up less vertical space.
* Removes individual selection of provided fonts Ezra and Noto Sans, keeping the hybrid version of the two listed.
* Cleans up code.
* If no graphite-enabled fonts are detected then that section simply does not display, rather than showing "none detected".
